### PR TITLE
Fix byte-order error and improve error reporting

### DIFF
--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -93,7 +93,20 @@ pub enum BtError {
 
 impl std::fmt::Display for BtError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{:}", std::error::Error::description(self))
+    }
+}
+
+impl std::error::Error for BtError {
+    fn description(&self) -> &str {
+        match self {
+            &BtError::Unknown =>
+                "Unknown Bluetooth Error",
+            &BtError::Errno(_, ref message) =>
+                message.as_str(),
+            &BtError::Desc(ref message) =>
+                message.as_str()
+        }
     }
 }
 

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -115,6 +115,30 @@ impl BtAddr {
         BtAddr ([0, 0, 0, 0, 0, 0])
     }
 
+    /// Linux lower-layers actually hold the address in native byte-order
+    /// althrough they are always displayed in network byte-order
+    #[doc(hidden)]
+    #[inline(always)]
+    #[cfg(target_endian = "little")]
+    pub fn convert_host_byteorder(mut self) -> BtAddr {
+        {
+            let (value_1, value_2) = (&mut self.0).split_at_mut(3);
+            std::mem::swap(&mut value_1[0], &mut value_2[2]);
+            std::mem::swap(&mut value_1[1], &mut value_2[1]);
+            std::mem::swap(&mut value_1[2], &mut value_2[0]);
+        }
+
+        self
+    }
+
+    #[doc(hidden)]
+    #[inline(always)]
+    #[cfg(target_endian = "big")]
+    pub fn convert_host_byteorder(self) -> BtAddr {
+        // Public address structure contents are always big-endian
+        self
+    }
+
     /// Converts a string of the format `XX:XX:XX:XX:XX:XX` to a `BtAddr`.
     pub fn from_str(s: &str) -> Result<BtAddr, ()> {
         let splits_iter = s.split(':');

--- a/src/linux/hci.rs
+++ b/src/linux/hci.rs
@@ -74,7 +74,7 @@ pub fn scan_devices() -> Result<Vec<BtDevice>, BtError> {
 
         devices.push(BtDevice {
             name: name,
-            addr: inquiry_info.bdaddr,
+            addr: inquiry_info.bdaddr.convert_host_byteorder(),
         })
     }
 

--- a/src/linux/socket.rs
+++ b/src/linux/socket.rs
@@ -34,6 +34,8 @@ impl BtSocket {
     }
 
     pub fn connect(&mut self, addr: BtAddr) -> Result<(), BtError> {
+        let addr = addr.convert_host_byteorder();
+        
         let full_address : sockaddr_rc = sockaddr_rc {
             rc_family : AF_BLUETOOTH as u16,
             rc_bdaddr : addr,


### PR DESCRIPTION
 1. Fix an error that would result in "inverted" MAC addresses on being transmitted on the network (compared to their visual representation).
    * i.e.: "01:02:03:04:05:06" would be transmitted as "\x06\x05\x04\x03\x02\x01"
 2. Improve error reporting in general